### PR TITLE
Update cached value for ObjectPreference before emitting to subscribers

### DIFF
--- a/rx-preferences/src/main/java/rx/android/preferences/ObjectPreference.java
+++ b/rx-preferences/src/main/java/rx/android/preferences/ObjectPreference.java
@@ -36,8 +36,8 @@ public class ObjectPreference<T> extends Preference<T> {
   @Override public void set(T value) {
     try {
       String serialized = converter.toString(value);
-      sharedPreferences.edit().putString(key, serialized).commit();
       this.value = value;
+      sharedPreferences.edit().putString(key, serialized).commit();
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/rx-preferences/src/test/java/rx/android/preferences/ObjectPreferenceTest.java
+++ b/rx-preferences/src/test/java/rx/android/preferences/ObjectPreferenceTest.java
@@ -1,0 +1,62 @@
+package rx.android.preferences;
+
+import android.content.SharedPreferences;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InOrder;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.IOException;
+
+import rx.Observer;
+import rx.Subscription;
+import rx.observers.TestObserver;
+
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.robolectric.shadows.ShadowPreferenceManager.getDefaultSharedPreferences;
+
+@RunWith(RobolectricTestRunner.class) //
+public class ObjectPreferenceTest {
+  SharedPreferences sharedPreferences;
+  ObjectPreference<String> preference;
+  final ObjectPreference.Converter<String> converter = new ObjectPreference.Converter<String>() {
+    @Override
+    public String fromString(String string) throws IOException {
+      return string;
+    }
+
+    @Override
+    public String toString(String string) throws IOException {
+      return string;
+    }
+  };
+
+  @Before
+  public void setUp() throws Exception {
+    sharedPreferences = getDefaultSharedPreferences(Robolectric.application);
+    sharedPreferences.edit().clear().commit();
+    preference = new ObjectPreference<String>(sharedPreferences, converter, "foo");
+    preference.set("bar");
+  }
+
+  @Test
+  public void subscriberIsInvokedWithNewValue() throws Exception {
+    Observer<String> observer = mock(Observer.class);
+    Subscription subscription = preference.toObservable() //
+            .subscribe(new TestObserver<String>(observer));
+    InOrder inOrder = inOrder(observer);
+
+    preference.set("baz");
+
+    inOrder.verify(observer, times(1)).onNext("bar");
+    inOrder.verify(observer, times(1)).onNext("baz");
+
+    subscription.unsubscribe();
+    TestUtils.verifyNoMoreInteractionsWithObserver(inOrder, observer);
+  }
+}


### PR DESCRIPTION
Avoids a "race condition" where the cached value isn't updated before subscribers are notified.