### PR TITLE
Implemented delete all preferences action.

### DIFF
--- a/rx-preferences-sample/src/main/java/com/f2prateek/rx/preferences/sample/SampleActivity.java
+++ b/rx-preferences-sample/src/main/java/com/f2prateek/rx/preferences/sample/SampleActivity.java
@@ -6,6 +6,7 @@ import android.os.Bundle;
 import android.widget.CheckBox;
 import butterknife.ButterKnife;
 import butterknife.InjectView;
+import butterknife.OnClick;
 import com.f2prateek.rx.preferences.Preference;
 import com.f2prateek.rx.preferences.RxSharedPreferences;
 import com.jakewharton.rxbinding.widget.RxCompoundButton;
@@ -20,6 +21,7 @@ public class SampleActivity extends Activity {
   @InjectView(R.id.foo_2) CheckBox foo2Checkbox;
   Preference<Boolean> fooPreference;
   CompositeSubscription subscriptions;
+  private RxSharedPreferences rxPreferences;
 
   @Override protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
@@ -30,7 +32,7 @@ public class SampleActivity extends Activity {
 
     // Preferences
     SharedPreferences preferences = getDefaultSharedPreferences(this);
-    RxSharedPreferences rxPreferences = RxSharedPreferences.create(preferences);
+    rxPreferences = RxSharedPreferences.create(preferences);
 
     // foo
     fooPreference = rxPreferences.getBoolean("foo");
@@ -58,5 +60,9 @@ public class SampleActivity extends Activity {
     subscriptions.add(RxCompoundButton.checkedChanges(checkBox)
         .skip(1)
         .subscribe(preference.asAction()));
+  }
+
+  @OnClick(R.id.btnClear) void onClearClick() {
+    rxPreferences.clear();
   }
 }

--- a/rx-preferences-sample/src/main/res/layout/sample_activity.xml
+++ b/rx-preferences-sample/src/main/res/layout/sample_activity.xml
@@ -22,4 +22,11 @@
       android:text="@string/foo"
       />
 
+  <Button
+      android:id="@+id/btnClear"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/clear"
+      />
+
 </LinearLayout>

--- a/rx-preferences-sample/src/main/res/values/strings.xml
+++ b/rx-preferences-sample/src/main/res/values/strings.xml
@@ -4,4 +4,5 @@
   <string name="app_name">Rx Preferences</string>
 
   <string name="foo">foo</string>
+  <string name="clear">clear all</string>
 </resources>

--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences/RxSharedPreferences.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences/RxSharedPreferences.java
@@ -171,4 +171,13 @@ public final class RxSharedPreferences {
     checkNotNull(key, "key == null");
     return new Preference<>(preferences, key, defaultValue, StringSetAdapter.INSTANCE, keyChanges);
   }
+
+  /** Delete all preferences.*/
+  public void clear() {
+    SharedPreferences.Editor editor = preferences.edit();
+    for (String key : preferences.getAll().keySet()) {
+      editor.remove(key);
+    }
+    editor.apply();
+  }
 }

--- a/rx-preferences/src/test/java/com/f2prateek/rx/preferences/RxSharedPreferencesTest.java
+++ b/rx-preferences/src/test/java/com/f2prateek/rx/preferences/RxSharedPreferencesTest.java
@@ -18,9 +18,10 @@ import static org.junit.Assert.fail;
 @SuppressWarnings({ "ResourceType", "ConstantConditions" }) //
 public class RxSharedPreferencesTest {
   private RxSharedPreferences rxPreferences;
+  private SharedPreferences preferences;
 
   @Before public void setUp() {
-    SharedPreferences preferences = getDefaultSharedPreferences(RuntimeEnvironment.application);
+    preferences = getDefaultSharedPreferences(RuntimeEnvironment.application);
     preferences.edit().clear().commit();
     rxPreferences = RxSharedPreferences.create(preferences);
   }
@@ -182,5 +183,12 @@ public class RxSharedPreferencesTest {
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("key == null");
     }
+  }
+
+  @Test public void clear() {
+    preferences.edit().putBoolean("foo1", true).commit();
+    preferences.edit().putString("foo2", "ROCK").commit();
+    rxPreferences.clear();
+    assertThat(preferences.getAll().isEmpty()).isTrue();
   }
 }


### PR DESCRIPTION
This is equivalent to calling `preference.delete()' for each preference.
Currently, there are different ways to achieve the same, but they are with flaws:
* call `delete` for each preference, but this is error-prone (easy to forget add a new preference).
* hold a reference to `SharedPreferences`, Not ideal, because you have to keep this reference, instead of just working with `RxSharedPreferences'