### PR TITLE
Return unmodifiable string set from preferences

### DIFF
--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/RxSharedPreferences.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/RxSharedPreferences.java
@@ -156,7 +156,10 @@ public final class RxSharedPreferences {
     return new RealPreference<>(preferences, key, defaultValue, StringAdapter.INSTANCE, keyChanges);
   }
 
-  /** Create a string set preference for {@code key}. Default is an empty set. */
+  /**
+   * Create a string set preference for {@code key}. Default is an empty set. Note that returned set
+   * value will always be unmodifiable.
+   */
   @RequiresApi(HONEYCOMB)
   @CheckResult @NonNull
   public Preference<Set<String>> getStringSet(@NonNull String key) {

--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/StringSetAdapter.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/StringSetAdapter.java
@@ -3,6 +3,7 @@ package com.f2prateek.rx.preferences2;
 import android.annotation.TargetApi;
 import android.content.SharedPreferences;
 import android.support.annotation.NonNull;
+import java.util.Collections;
 import java.util.Set;
 
 import static android.os.Build.VERSION_CODES.HONEYCOMB;
@@ -14,7 +15,7 @@ final class StringSetAdapter implements Preference.Adapter<Set<String>> {
   @Override public Set<String> get(@NonNull String key, @NonNull SharedPreferences preferences) {
     Set<String> value = preferences.getStringSet(key, null);
     assert value != null; // Not called unless key is present.
-    return value;
+    return Collections.unmodifiableSet(value);
   }
 
   @Override public void set(@NonNull String key, @NonNull Set<String> value,

--- a/rx-preferences/src/test/java/com/f2prateek/rx/preferences2/PreferenceTest.java
+++ b/rx-preferences/src/test/java/com/f2prateek/rx/preferences2/PreferenceTest.java
@@ -3,6 +3,8 @@ package com.f2prateek.rx.preferences2;
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
 import io.reactivex.functions.Consumer;
+import java.util.LinkedHashSet;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -14,7 +16,7 @@ import static android.preference.PreferenceManager.getDefaultSharedPreferences;
 import static com.f2prateek.rx.preferences2.Roshambo.ROCK;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.extractProperty;
+import static org.assertj.core.api.Assertions.fail;
 
 @RunWith(RobolectricTestRunner.class) //
 @SuppressLint({ "NewApi", "CommitPrefEdits" }) //
@@ -167,6 +169,29 @@ public class PreferenceTest {
 
     preference.delete();
     assertThat(preferences.contains("foo")).isFalse();
+  }
+
+  @Test public void stringSetDefaultIsUnmodifiable() {
+    Preference<Set<String>> preference = rxPreferences.getStringSet("foo");
+    Set<String> stringSet = preference.get();
+    try {
+      stringSet.add("");
+      fail(stringSet.getClass() + " should not be modifiable.");
+    } catch (UnsupportedOperationException expected) {
+      assertThat(expected).hasNoCause();
+    }
+  }
+
+  @Test public void stringSetIsUnmodifiable() {
+    Preference<Set<String>> preference = rxPreferences.getStringSet("foo");
+    preference.set(new LinkedHashSet<String>());
+    Set<String> stringSet = preference.get();
+    try {
+      stringSet.add("");
+      fail(stringSet.getClass() + " should not be modifiable.");
+    } catch (UnsupportedOperationException expected) {
+      assertThat(expected).hasNoCause();
+    }
   }
 
   @Test public void asObservable() {


### PR DESCRIPTION
https://developer.android.com/reference/android/content/SharedPreferences.html#getStringSet(java.lang.String,%20java.util.Set%3Cjava.lang.String%3E)

This can cause subtle errors and ConcurrentModificationExceptions if the set is mutated by the caller.
This is a breaking change, but I thought I'd propose it, anyway. :)
Also, it could just return a mutable copy (`new LinkedHashSet<>()` instead of `unmodifiableSet()`) to be a compatible change.