### PR TITLE
Fix possible inconsistency between contains and get calls.

### DIFF
--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/RealPreference.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/RealPreference.java
@@ -58,14 +58,14 @@ final class RealPreference<T> implements Preference<T> {
     return defaultValue;
   }
 
-  @Override @NonNull public T get() {
+  @Override @NonNull public synchronized T get() {
     if (!preferences.contains(key)) {
       return defaultValue;
     }
     return adapter.get(key, preferences);
   }
 
-  @Override public void set(@Nullable T value) {
+  @Override public synchronized void set(@Nullable T value) {
     SharedPreferences.Editor editor = preferences.edit();
     if (value == null) {
       editor.remove(key);


### PR DESCRIPTION
Before this change, if delete is called in between the contains check
and the Adapter’s get call, the AssertionError will be thrown.

Closes #79.