### PR TITLE
Always return an unmodifiable set.

### DIFF
--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/RxSharedPreferences.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/RxSharedPreferences.java
@@ -4,13 +4,13 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
-import android.support.annotation.Nullable;
 import android.support.annotation.RequiresApi;
 import io.reactivex.Observable;
 import io.reactivex.ObservableEmitter;
 import io.reactivex.ObservableOnSubscribe;
 import io.reactivex.functions.Cancellable;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 import static android.os.Build.VERSION_CODES.HONEYCOMB;
@@ -167,9 +167,11 @@ public final class RxSharedPreferences {
       @NonNull Set<String> defaultValue) {
     checkNotNull(key, "key == null");
     checkNotNull(defaultValue, "defaultValue == null");
-    return new RealPreference<>(preferences, key, defaultValue, StringSetAdapter.INSTANCE, keyChanges);
+    return new RealPreference<>(preferences, key,
+        Collections.unmodifiableSet(new LinkedHashSet<>(defaultValue)), StringSetAdapter.INSTANCE,
+        keyChanges);
   }
-  
+
   public void clear() {
     preferences.edit().clear().apply();
   }

--- a/rx-preferences/src/test/java/com/f2prateek/rx/preferences2/PreferenceTest.java
+++ b/rx-preferences/src/test/java/com/f2prateek/rx/preferences2/PreferenceTest.java
@@ -226,12 +226,26 @@ public class PreferenceTest {
     }
   }
 
-  @Test public void stringSetDefaultIsUnmodifiable() {
+  @Test public void stringSetDefaultDefaultIsUnmodifiable() {
     Preference<Set<String>> preference = rxPreferences.getStringSet("foo");
     Set<String> stringSet = preference.get();
     try {
       stringSet.add("");
-      fail(stringSet.getClass() + " should not be modifiable.");
+      fail("Preference<Set<String>>.get() should not return a modifiable set.");
+    } catch (UnsupportedOperationException expected) {
+      assertThat(expected).hasNoCause();
+    }
+  }
+
+  @Test public void stringSetDefaultIsCopiedAndUnmodifiable() {
+    LinkedHashSet<String> mutableDefault = new LinkedHashSet<>();
+    Preference<Set<String>> preference = rxPreferences.getStringSet("foo", mutableDefault);
+    mutableDefault.add("");
+    Set<String> stringSet = preference.get();
+    assertThat(stringSet).isEmpty();
+    try {
+      stringSet.add("");
+      fail("Preference<Set<String>>.get() should not return a modifiable set.");
     } catch (UnsupportedOperationException expected) {
       assertThat(expected).hasNoCause();
     }
@@ -243,7 +257,7 @@ public class PreferenceTest {
     Set<String> stringSet = preference.get();
     try {
       stringSet.add("");
-      fail(stringSet.getClass() + " should not be modifiable.");
+      fail("Preference<Set<String>>.get() should not return a modifiable set.");
     } catch (UnsupportedOperationException expected) {
       assertThat(expected).hasNoCause();
     }


### PR DESCRIPTION
This makes the behavior consistent across default and set values.