### PR TITLE
Replace asAction with asConsumer in readme and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Subscribe preferences to streams to store values:
 
 ```java
 RxCompoundButton.checks(showWhatsNewView)
-    .subscribe(showWhatsNew.asAction());
+    .subscribe(showWhatsNew.asConsumer());
 ```
 *(Note: `RxCompoundButton` is from [RxBinding][1])*
 

--- a/rx-preferences/src/test/java/com/f2prateek/rx/preferences2/PreferenceTest.java
+++ b/rx-preferences/src/test/java/com/f2prateek/rx/preferences2/PreferenceTest.java
@@ -263,7 +263,7 @@ public class PreferenceTest {
     observer.assertValue("bar");
   }
 
-  @Test public void asAction() throws Exception {
+  @Test public void asConsumer() throws Exception {
     Preference<String> preference = rxPreferences.getString("foo");
     Consumer<? super String> consumer = preference.asConsumer();
 


### PR DESCRIPTION
Readme and Tests still contained removed method asAction -  replaced with asConsumer