### PR TITLE
Fix usage of String.split

### DIFF
--- a/rx-preferences/src/test/java/com/f2prateek/rx/preferences2/PointPreferenceConverter.java
+++ b/rx-preferences/src/test/java/com/f2prateek/rx/preferences2/PointPreferenceConverter.java
@@ -4,7 +4,7 @@ import android.support.annotation.NonNull;
 
 final class PointPreferenceConverter implements Preference.Converter<Point> {
   @NonNull @Override public Point deserialize(@NonNull String serialized) {
-    String[] parts = serialized.split(",");
+    String[] parts = serialized.split(",", -1);
     if (parts.length != 2) {
       throw new IllegalStateException("Malformed point value: '" + serialized + "'");
     }


### PR DESCRIPTION
The build currently fails with this error:

```
/Users/prateek/dev/src/github.com/f2prateek/rx-preferences/rx-preferences/src/test/java/com/f2prateek/rx/preferences2/PointPreferenceConverter.java:7: warning: [StringSplitter] String.split(String) has surprising behavior
    String[] parts = serialized.split(",");
                                     ^
    (see http://errorprone.info/bugpattern/StringSplitter)
  Did you mean 'String[] parts = serialized.split(",", -1);'?
error: warnings found and -Werror specified
1 error
```

This fixes the usage of String.split as recommended by http://errorprone.info/bugpattern/StringSplitter.