### PR TITLE
Prevents null values from being returned.

### DIFF
--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/BooleanAdapter.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/BooleanAdapter.java
@@ -1,14 +1,14 @@
 package com.f2prateek.rx.preferences2;
 
 import android.content.SharedPreferences;
-
 import androidx.annotation.NonNull;
 
 final class BooleanAdapter implements RealPreference.Adapter<Boolean> {
   static final BooleanAdapter INSTANCE = new BooleanAdapter();
 
-  @Override public Boolean get(@NonNull String key, @NonNull SharedPreferences preferences) {
-    return preferences.getBoolean(key, false);
+  @NonNull @Override public Boolean get(@NonNull String key, @NonNull SharedPreferences preferences,
+      @NonNull Boolean defaultValue) {
+    return preferences.getBoolean(key, defaultValue);
   }
 
   @Override public void set(@NonNull String key, @NonNull Boolean value,

--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/ConverterAdapter.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/ConverterAdapter.java
@@ -1,7 +1,6 @@
 package com.f2prateek.rx.preferences2;
 
 import android.content.SharedPreferences;
-
 import androidx.annotation.NonNull;
 
 import static com.f2prateek.rx.preferences2.Preconditions.checkNotNull;
@@ -13,9 +12,11 @@ final class ConverterAdapter<T> implements RealPreference.Adapter<T> {
     this.converter = converter;
   }
 
-  @Override public T get(@NonNull String key, @NonNull SharedPreferences preferences) {
+  @NonNull @Override public T get(@NonNull String key, @NonNull SharedPreferences preferences,
+      @NonNull T defaultValue) {
     String serialized = preferences.getString(key, null);
-    assert serialized != null; // Not called unless key is present.
+    if (serialized == null) return defaultValue;
+
     T value = converter.deserialize(serialized);
     checkNotNull(value, "Deserialized value must not be null from string: " + serialized);
     return value;

--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/EnumAdapter.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/EnumAdapter.java
@@ -1,7 +1,6 @@
 package com.f2prateek.rx.preferences2;
 
 import android.content.SharedPreferences;
-
 import androidx.annotation.NonNull;
 
 final class EnumAdapter<T extends Enum<T>> implements RealPreference.Adapter<T> {
@@ -11,9 +10,10 @@ final class EnumAdapter<T extends Enum<T>> implements RealPreference.Adapter<T> 
     this.enumClass = enumClass;
   }
 
-  @Override public T get(@NonNull String key, @NonNull SharedPreferences preferences) {
+  @NonNull @Override public T get(@NonNull String key, @NonNull SharedPreferences preferences,
+      @NonNull T defaultValue) {
     String value = preferences.getString(key, null);
-    assert value != null; // Not called unless key is present.
+    if (value == null) return defaultValue;
     return Enum.valueOf(enumClass, value);
   }
 

--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/FloatAdapter.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/FloatAdapter.java
@@ -1,14 +1,14 @@
 package com.f2prateek.rx.preferences2;
 
 import android.content.SharedPreferences;
-
 import androidx.annotation.NonNull;
 
 final class FloatAdapter implements RealPreference.Adapter<Float> {
   static final FloatAdapter INSTANCE = new FloatAdapter();
 
-  @Override public Float get(@NonNull String key, @NonNull SharedPreferences preferences) {
-    return preferences.getFloat(key, 0f);
+  @NonNull @Override public Float get(@NonNull String key, @NonNull SharedPreferences preferences,
+      @NonNull Float defaultValue) {
+    return preferences.getFloat(key, defaultValue);
   }
 
   @Override public void set(@NonNull String key, @NonNull Float value,

--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/IntegerAdapter.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/IntegerAdapter.java
@@ -1,14 +1,14 @@
 package com.f2prateek.rx.preferences2;
 
 import android.content.SharedPreferences;
-
 import androidx.annotation.NonNull;
 
 final class IntegerAdapter implements RealPreference.Adapter<Integer> {
   static final IntegerAdapter INSTANCE = new IntegerAdapter();
 
-  @Override public Integer get(@NonNull String key, @NonNull SharedPreferences preferences) {
-    return preferences.getInt(key, 0);
+  @NonNull @Override public Integer get(@NonNull String key, @NonNull SharedPreferences preferences,
+      @NonNull Integer defaultValue) {
+    return preferences.getInt(key, defaultValue);
   }
 
   @Override public void set(@NonNull String key, @NonNull Integer value,

--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/LongAdapter.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/LongAdapter.java
@@ -1,14 +1,14 @@
 package com.f2prateek.rx.preferences2;
 
 import android.content.SharedPreferences;
-
 import androidx.annotation.NonNull;
 
 final class LongAdapter implements RealPreference.Adapter<Long> {
   static final LongAdapter INSTANCE = new LongAdapter();
 
-  @Override public Long get(@NonNull String key, @NonNull SharedPreferences preferences) {
-    return preferences.getLong(key, 0L);
+  @NonNull @Override public Long get(@NonNull String key, @NonNull SharedPreferences preferences,
+      @NonNull Long defaultValue) {
+    return preferences.getLong(key, defaultValue);
   }
 
   @Override public void set(@NonNull String key, @NonNull Long value,

--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/StringAdapter.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/StringAdapter.java
@@ -1,16 +1,17 @@
 package com.f2prateek.rx.preferences2;
 
 import android.content.SharedPreferences;
-
 import androidx.annotation.NonNull;
+
+import static com.f2prateek.rx.preferences2.Preconditions.checkNotNull;
 
 final class StringAdapter implements RealPreference.Adapter<String> {
   static final StringAdapter INSTANCE = new StringAdapter();
 
-  @Override public String get(@NonNull String key, @NonNull SharedPreferences preferences) {
-    String value = preferences.getString(key, null);
-    assert value != null; // Not called unless key is present.
-    return value;
+  @NonNull @Override public String get(@NonNull String key, @NonNull SharedPreferences preferences,
+      @NonNull String defaultValue) {
+    //noinspection ConstantConditions
+    return preferences.getString(key, defaultValue);
   }
 
   @Override public void set(@NonNull String key, @NonNull String value,

--- a/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/StringSetAdapter.java
+++ b/rx-preferences/src/main/java/com/f2prateek/rx/preferences2/StringSetAdapter.java
@@ -2,22 +2,18 @@ package com.f2prateek.rx.preferences2;
 
 import android.annotation.TargetApi;
 import android.content.SharedPreferences;
-
 import androidx.annotation.NonNull;
-
-import java.util.Collections;
 import java.util.Set;
 
 import static android.os.Build.VERSION_CODES.HONEYCOMB;
+import static java.util.Collections.unmodifiableSet;
 
-@TargetApi(HONEYCOMB)
-final class StringSetAdapter implements RealPreference.Adapter<Set<String>> {
+@TargetApi(HONEYCOMB) final class StringSetAdapter implements RealPreference.Adapter<Set<String>> {
   static final StringSetAdapter INSTANCE = new StringSetAdapter();
 
-  @Override public Set<String> get(@NonNull String key, @NonNull SharedPreferences preferences) {
-    Set<String> value = preferences.getStringSet(key, null);
-    assert value != null; // Not called unless key is present.
-    return Collections.unmodifiableSet(value);
+  @NonNull @Override public Set<String> get(@NonNull String key,
+      @NonNull SharedPreferences preferences, @NonNull Set<String> defaultValue) {
+    return unmodifiableSet(preferences.getStringSet(key, defaultValue));
   }
 
   @Override public void set(@NonNull String key, @NonNull Set<String> value,

--- a/rx-preferences/src/test/java/com/f2prateek/rx/preferences2/PreferenceTest.java
+++ b/rx-preferences/src/test/java/com/f2prateek/rx/preferences2/PreferenceTest.java
@@ -2,24 +2,23 @@ package com.f2prateek.rx.preferences2;
 
 import android.annotation.SuppressLint;
 import android.content.SharedPreferences;
-
 import androidx.annotation.NonNull;
 import androidx.test.core.app.ApplicationProvider;
-
+import io.reactivex.functions.Consumer;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 
-import java.util.LinkedHashSet;
-import java.util.Set;
-
-import io.reactivex.functions.Consumer;
-
 import static android.preference.PreferenceManager.getDefaultSharedPreferences;
 import static com.f2prateek.rx.preferences2.Roshambo.PAPER;
 import static com.f2prateek.rx.preferences2.Roshambo.ROCK;
+import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
@@ -283,5 +282,55 @@ public class PreferenceTest {
     } catch (NullPointerException e) {
       assertThat(e).hasMessage("value == null");
     }
+  }
+
+  @Test public void legacyNullString() {
+    nullValue("string");
+    assertThat(rxPreferences.getString("string", "default").get()).isEqualTo("default");
+  }
+
+  @Test public void legacyNullBoolean() {
+    nullValue("bool");
+    assertThat(rxPreferences.getBoolean("bool", true).get()).isEqualTo(true);
+  }
+
+  @Test public void legacyNullEnum() {
+    nullValue("enum");
+    assertThat(rxPreferences.getEnum("enum", PAPER, Roshambo.class).get()).isEqualTo(PAPER);
+  }
+
+  @Test public void legacyNullFloat() {
+    nullValue("float");
+    assertThat(rxPreferences.getFloat("float", 123.45f).get()).isEqualTo(123.45f);
+  }
+
+  @Test public void legacyNullInteger() {
+    nullValue("int");
+    assertThat(rxPreferences.getInteger("int", 12345).get()).isEqualTo(12345);
+  }
+
+  @Test public void legacyNullLong() {
+    nullValue("long");
+    assertThat(rxPreferences.getLong("long", 12345L).get()).isEqualTo(12345L);
+  }
+
+  @Test public void legacyNullObject() {
+    nullValue("obj");
+    assertThat(rxPreferences.getObject("obj", new Point(10, 11), pointConverter).get())
+        .isEqualTo(new Point(10, 11));
+  }
+
+  @Test public void legacyNullSet() {
+    nullValue("set");
+    List<String> strings = asList("able", "baker", "charlie");
+    HashSet<String> defaultSet = new HashSet<>(strings);
+    HashSet<String> expectedSet = new HashSet<>(strings);
+    assertThat(rxPreferences.getStringSet("key", defaultSet).get()).isEqualTo(expectedSet);
+  }
+
+  private void nullValue(String key) {
+    preferences.edit()
+        .putString(key, null)
+        .commit();
   }
 }


### PR DESCRIPTION
Puts `Adapter` instances in charge of using default values as needed. This
allows them to guard against that fact that null values can be pushed into
`SharedPreferences` behind our backs.

Fixes #131.